### PR TITLE
fix(match): unify calculation for fulfillment

### DIFF
--- a/src/components/matches/StandMatchDetail.tsx
+++ b/src/components/matches/StandMatchDetail.tsx
@@ -2,6 +2,7 @@ import { Alert } from "@mui/material";
 import React from "react";
 import { StandMatchWithDetails } from "../../utils/types";
 import {
+  calculateFulfilledStandMatchItems,
   calculateItemStatuses,
   ItemStatus,
   MatchHeader,
@@ -18,12 +19,8 @@ const StandMatchDetail = ({
   match: StandMatchWithDetails;
   currentUserId: string;
 }) => {
-  const fulfilledHandoffItems = match.expectedHandoffItems.filter((item) =>
-    match.deliveredItems.includes(item)
-  );
-  const fulfilledPickupItems = match.expectedPickupItems.filter((item) =>
-    match.receivedItems.includes(item)
-  );
+  const { fulfilledHandoffItems, fulfilledPickupItems } =
+    calculateFulfilledStandMatchItems(match);
   const isFulfilled =
     fulfilledHandoffItems.length >= match.expectedHandoffItems.length &&
     fulfilledPickupItems.length >= match.expectedPickupItems.length;

--- a/src/components/matches/UserMatchDetail.tsx
+++ b/src/components/matches/UserMatchDetail.tsx
@@ -2,6 +2,7 @@ import { Alert } from "@mui/material";
 import React, { useCallback, useState } from "react";
 import { UserMatchWithDetails } from "../../utils/types";
 import {
+  calculateFulfilledUserMatchCustomerItems,
   calculateItemStatuses,
   ItemStatus,
   MatchHeader,
@@ -22,11 +23,13 @@ const UserMatchDetail = ({
   const [, updateState] = useState({});
   const forceUpdate = useCallback(() => updateState({}), []);
   const isSender = match.sender === currentUserId;
-  const fulfilledItems = match.expectedItems.filter((item) =>
-    (isSender
-      ? match.deliveredCustomerItems
-      : match.receivedCustomerItems
-    ).some((customerItem) => match.customerItemToItemMap[customerItem] === item)
+  const fulfilledItems = calculateFulfilledUserMatchCustomerItems(
+    match,
+    isSender
+  );
+  const otherPersonFulfilledItems = calculateFulfilledUserMatchCustomerItems(
+    match,
+    !isSender
   );
   const isFulfilled = fulfilledItems.length >= match.expectedItems.length;
 
@@ -49,6 +52,13 @@ const UserMatchDetail = ({
           overleveringen.
         </Alert>
       )}
+      {fulfilledItems.length !== otherPersonFulfilledItems.length &&
+        isSender && (
+          <Alert severity={"warning"} sx={{ mt: "1rem" }}>
+            Noen av bøkene du har levert har vært på andres vegne. Ta kontakt
+            med stand for mer informasjon.
+          </Alert>
+        )}
 
       <ProgressBar
         percentComplete={

--- a/src/components/matches/matchesList/StandMatchListItem.tsx
+++ b/src/components/matches/matchesList/StandMatchListItem.tsx
@@ -1,20 +1,27 @@
-import { StandMatch } from "@boklisten/bl-model";
 import { Box } from "@mui/material";
 import React from "react";
-import { formatActionsString, matchBegun, matchFulfilled } from "./helper";
+import { formatActionsString } from "./helper";
 import MatchListItemBox from "./MatchListItemBox";
 import ProgressBar from "./ProgressBar";
+import {
+  calculateFulfilledStandMatchItems,
+  isMatchBegun,
+  isMatchFulfilled,
+} from "../matches-helper";
+import { StandMatchWithDetails } from "utils/types";
 
 const StandMatchListItem: React.FC<{
-  match: StandMatch;
+  match: StandMatchWithDetails;
   currentUserId: string;
 }> = ({ match }) => {
   const numberHandoffItems = match.expectedHandoffItems.length;
   const numberPickupItems = match.expectedPickupItems.length;
   const hasHandoffItems = numberHandoffItems > 0;
   const hasPickupItems = numberPickupItems > 0;
-  const isBegun = matchBegun(match);
-  const isFulfilled = matchFulfilled(match);
+  const { fulfilledPickupItems, fulfilledHandoffItems } =
+    calculateFulfilledStandMatchItems(match);
+  const isBegun = isMatchBegun(match, false);
+  const isFulfilled = isMatchFulfilled(match, false);
   return (
     <MatchListItemBox finished={isFulfilled} matchId={match.id}>
       {isBegun && (
@@ -23,12 +30,12 @@ const StandMatchListItem: React.FC<{
             <>
               <ProgressBar
                 percentComplete={
-                  (match.deliveredItems.length * 100) / numberHandoffItems
+                  (fulfilledHandoffItems.length * 100) / numberHandoffItems
                 }
                 subtitle={
                   <Box>
-                    Levert {match.deliveredItems.length} av {numberHandoffItems}{" "}
-                    bøker
+                    Levert {fulfilledHandoffItems.length} av{" "}
+                    {numberHandoffItems} bøker
                   </Box>
                 }
               />
@@ -38,11 +45,11 @@ const StandMatchListItem: React.FC<{
             <>
               <ProgressBar
                 percentComplete={
-                  (match.receivedItems.length * 100) / numberPickupItems
+                  (fulfilledPickupItems.length * 100) / numberPickupItems
                 }
                 subtitle={
                   <Box>
-                    Mottatt {match.receivedItems.length} av {numberPickupItems}{" "}
+                    Mottatt {fulfilledPickupItems.length} av {numberPickupItems}{" "}
                     bøker
                   </Box>
                 }

--- a/src/components/matches/matchesList/UserMatchListItem.tsx
+++ b/src/components/matches/matchesList/UserMatchListItem.tsx
@@ -1,11 +1,16 @@
 import React from "react";
-import { formatActionsString, matchBegun, matchFulfilled } from "./helper";
+import { formatActionsString } from "./helper";
 import MatchListItemBox from "./MatchListItemBox";
-import { Alert, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { KeyboardDoubleArrowRight } from "@mui/icons-material";
 import ProgressBar from "./ProgressBar";
-import { Box } from "@mui/material";
 import { UserMatchWithDetails } from "../../../utils/types";
+import {
+  calculateFulfilledUserMatchCustomerItems,
+  isMatchBegun,
+  isMatchFulfilled,
+  isUserSenderInMatch,
+} from "../matches-helper";
 
 const me = <span style={{ color: "#757575", fontWeight: 400 }}>Meg</span>;
 
@@ -14,12 +19,14 @@ const UserMatchListItem: React.FC<{
   currentUserId: string;
 }> = ({ match, currentUserId }) => {
   const numberItems = match.expectedItems.length;
-  const isBegun = matchBegun(match);
-  const isFulfilled = matchFulfilled(match);
-  const isSender = match.sender === currentUserId;
+  const isSender = isUserSenderInMatch(match, currentUserId);
+  const isBegun = isMatchBegun(match, isSender);
+  const isFulfilled = isMatchFulfilled(match, isSender);
+  const fulfilledItems = calculateFulfilledUserMatchCustomerItems(
+    match,
+    isSender
+  );
   const HeaderLevel = "h4";
-  const deliveredCount = match.deliveredCustomerItems.length;
-  const receivedCount = match.receivedCustomerItems.length;
   return (
     <MatchListItemBox finished={isFulfilled} matchId={match.id}>
       {isSender ? (
@@ -43,20 +50,11 @@ const UserMatchListItem: React.FC<{
       {isBegun && (
         <>
           <ProgressBar
-            percentComplete={
-              ((isSender ? deliveredCount : receivedCount) * 100) / numberItems
-            }
+            percentComplete={(fulfilledItems.length * 100) / numberItems}
             subtitle={
               <Box>
-                {isSender ? "Levert" : "Mottatt"}{" "}
-                {isSender ? deliveredCount : receivedCount} av {numberItems}{" "}
-                bøker
-                {isSender && deliveredCount !== receivedCount && (
-                  <Alert severity={"warning"} sx={{ mt: "1rem" }}>
-                    Noen av bøkene du har levert har vært på andres vegne. Ta
-                    kontakt med stand for mer informasjon.
-                  </Alert>
-                )}
+                {isSender ? "Levert" : "Mottatt"} {fulfilledItems.length} av{" "}
+                {numberItems} bøker
               </Box>
             }
           />

--- a/src/components/matches/matchesList/helper.tsx
+++ b/src/components/matches/matchesList/helper.tsx
@@ -1,4 +1,4 @@
-import { Match, MatchVariant, MatchWithDetails } from "@boklisten/bl-model";
+import { MatchWithDetails } from "@boklisten/bl-model";
 import { Properties } from "csstype";
 import { GroupedMatches } from "../../../utils/types";
 
@@ -7,19 +7,6 @@ export const sectionStyle: Properties = {
   flexDirection: "column",
   gap: "1em",
 };
-
-export function matchFulfilled(match: Match): boolean {
-  return match._variant === MatchVariant.StandMatch
-    ? match.deliveredItems.length >= match.expectedHandoffItems.length &&
-        match.receivedItems.length >= match.expectedPickupItems.length
-    : match.receivedCustomerItems.length >= match.expectedItems.length;
-}
-
-export function matchBegun(match: Match): boolean {
-  return match._variant === MatchVariant.StandMatch
-    ? match.deliveredItems.length > 0 || match.receivedItems.length > 0
-    : match.receivedCustomerItems.length > 0;
-}
 
 export function formatActionsString(handoffItems: number, pickupItems: number) {
   const hasHandoffItems = handoffItems > 0;


### PR DESCRIPTION
Previously, different ways of calculating Item/CustomerItem/Match
fulfillment were used in different places, leading to inconsistency.
Now, they are all unified to this algorithm:
- an Item is fulfilled if an Item with the same ID is registered
- a CustomerItem is fulfilled if a CustomerItem with the same Item is
  registered
- a Match is fulfilled if all its expected Items/CustomerItems are fulfilled

This prevents the 'Mottat 2 av 1'-bug in /matches.
