### PR TITLE
feat(scanner): immediately refresh match on scan

### DIFF
--- a/src/components/matches/MatchDetail.tsx
+++ b/src/components/matches/MatchDetail.tsx
@@ -17,7 +17,11 @@ const MatchDetail = ({ matchId }: { matchId: string }) => {
   );
   const userId = accessToken?.details;
 
-  const { data: matches, error: matchesError } = useSWR(
+  const {
+    data: matches,
+    error: matchesError,
+    mutate: updateMatches,
+  } = useSWR(
     `${BL_CONFIG.collection.match}/me`,
     apiFetcher<MatchWithDetails[]>,
     { refreshInterval: 5000 },
@@ -64,7 +68,11 @@ const MatchDetail = ({ matchId }: { matchId: string }) => {
           <StandMatchDetail match={match} />
         )}
         {match._variant === MatchVariant.UserMatch && (
-          <UserMatchDetail match={match} currentUserId={userId} />
+          <UserMatchDetail
+            match={match}
+            currentUserId={userId}
+            handleItemTransferred={() => updateMatches()}
+          />
         )}
       </Container>
     </Card>

--- a/src/components/matches/UserMatchDetail.tsx
+++ b/src/components/matches/UserMatchDetail.tsx
@@ -21,9 +21,11 @@ import { UserMatchWithDetails } from "@/utils/types";
 const UserMatchDetail = ({
   match,
   currentUserId,
+  handleItemTransferred,
 }: {
   match: UserMatchWithDetails;
   currentUserId: string;
+  handleItemTransferred?: (() => void) | undefined;
 }) => {
   const [scanModalOpen, setScanModalOpen] = useState(false);
   const [redirectCountdownStarted, setRedirectCountdownStarted] =
@@ -136,6 +138,7 @@ const UserMatchDetail = ({
 
       <ScannerModal
         open={scanModalOpen}
+        handleItemTransferred={handleItemTransferred}
         handleClose={() => {
           setScanModalOpen(false);
           setRedirectCountdownStarted(isFulfilled);


### PR DESCRIPTION
Improve the time from scanning until the match visually updating by
immediately refreshing from the API on succesful scan. Would be even
faster to optimistically update the local cache of the date, but that's
harder and not really necessary.
Also rate limited the API transfer call to 4x per second as the API did
not handle races well, leading to some cases of multiple customerItems
active at the same time for one item, which caused a "not active" error
in the scanner as number active == 1 is an assert in the API.
